### PR TITLE
[csvmum] add time layout parsing

### DIFF
--- a/pkg/csvmum/common.go
+++ b/pkg/csvmum/common.go
@@ -43,7 +43,11 @@ func getHeaderData(t reflect.Type) (map[string]fieldData, error) {
 }
 
 func getFieldData(f reflect.StructField, idx int) fieldData {
-	fd := initFieldData(f.Name, idx)
+	fd := fieldData{
+		name:       f.Name,
+		idx:        idx,
+		timeLayout: time.RFC3339,
+	}
 
 	if f.IsExported() {
 		fd.exported = true
@@ -79,14 +83,6 @@ func getFieldData(f reflect.StructField, idx int) fieldData {
 		}
 	}
 	return fd
-}
-
-func initFieldData(n string, i int) fieldData {
-	return fieldData{
-		name:       n,
-		idx:        i,
-		timeLayout: time.RFC3339,
-	}
 }
 
 func getOrderedHeaders(hm map[string]fieldData) []string {

--- a/pkg/csvmum/common.go
+++ b/pkg/csvmum/common.go
@@ -55,9 +55,8 @@ func getFieldData(f reflect.StructField, idx int) fieldData {
 		if tag, ok := f.Tag.Lookup("csv"); ok {
 			tags := strings.Split(tag, ",")
 			for i, tag := range tags {
-				switch i {
-				// name is always first
-				case 0:
+				if i == 0 {
+					// name is always first
 					switch tag {
 					case "-":
 						// ignore the field
@@ -68,8 +67,8 @@ func getFieldData(f reflect.StructField, idx int) fieldData {
 						// use the tag as the name
 						fd.name = tag
 					}
-				// all other tags can be in any order
-				default:
+				} else {
+					// all other tags can be in any order
 					b := builtin.FindStringSubmatch(tag)
 					if len(b) == 3 {
 						switch b[1] {

--- a/pkg/csvmum/marshal.go
+++ b/pkg/csvmum/marshal.go
@@ -19,12 +19,12 @@ func Marshal(v any) ([][]string, error) {
 	}
 
 	typ := reflect.ValueOf(s.Index(0).Interface()).Type()
-	hm, err := getHeaderNamesToIndices(typ)
+	hd, err := getHeaderData(typ)
 	if err != nil {
 		return out, err
 	}
 
-	hs := getOrderedHeaders(hm)
+	hs := getOrderedHeaders(hd)
 
 	out = append(out, hs)
 
@@ -32,7 +32,7 @@ func Marshal(v any) ([][]string, error) {
 		item := s.Index(i)
 		record := []string{}
 		for _, n := range hs {
-			field := item.Field(hm[n])
+			field := item.Field(hd[n].idx)
 			switch field.Kind() {
 			case reflect.String:
 				record = append(record, fmt.Sprintf("%s", field.String()))

--- a/pkg/csvmum/marshal.go
+++ b/pkg/csvmum/marshal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 )
 
 func Marshal(v any) ([][]string, error) {
@@ -42,6 +43,12 @@ func Marshal(v any) ([][]string, error) {
 				record = append(record, fmt.Sprintf("%t", field.Bool()))
 			case reflect.Float64:
 				record = append(record, fmt.Sprintf("%s", strconv.FormatFloat(field.Float(), 'f', -1, 64)))
+			case reflect.Struct:
+				switch field.Type() {
+				case timeType:
+					record = append(record, fmt.Sprintf("%s", field.Interface().(time.Time).Format(hd[n].timeLayout)))
+				default:
+				}
 			}
 		}
 		out = append(out, record)

--- a/pkg/csvmum/marshal_test.go
+++ b/pkg/csvmum/marshal_test.go
@@ -3,6 +3,7 @@ package csvmum
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -52,6 +53,11 @@ func TestMarshal(t *testing.T) {
 			Three float64
 		}{{One: "one", two: 2, Three: 67.3}},
 		expected: [][]string{{"One", "Three"}, {"one", "67.3"}},
+		err:      nil,
+	}, {
+		name:     "time",
+		input:    []struct{ One time.Time }{{One: time.Date(2024, 11, 24, 12, 04, 0, 0, time.UTC)}},
+		expected: [][]string{{"One"}, {"2024-11-24T12:04:00Z"}},
 		err:      nil,
 	}}
 

--- a/pkg/csvmum/unmarshal.go
+++ b/pkg/csvmum/unmarshal.go
@@ -22,7 +22,7 @@ func Unmarshal(data [][]string, v any) error {
 	}
 
 	typ := pe.Type().Elem()
-	ftoi, err := getHeaderNamesToIndices(typ)
+	hd, err := getHeaderData(typ)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal: %v", err)
 	}
@@ -32,9 +32,9 @@ func Unmarshal(data [][]string, v any) error {
 		return fmt.Errorf("cannot unmarshal: no headers")
 	}
 
-	hm := map[int]int{}
+	hm := map[int]fieldData{}
 	for i, h := range headers {
-		if j, ok := ftoi[h]; ok {
+		if j, ok := hd[h]; ok {
 			hm[i] = j
 		}
 	}
@@ -53,7 +53,7 @@ func Unmarshal(data [][]string, v any) error {
 
 		n := reflect.New(typ).Elem()
 		for i, j := range hm {
-			f := n.Field(j)
+			f := n.Field(j.idx)
 			switch f.Kind() {
 			case reflect.String:
 				f.SetString(record[i])

--- a/pkg/csvmum/unmarshal.go
+++ b/pkg/csvmum/unmarshal.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
+)
+
+var (
+	timeType = reflect.TypeOf(time.Time{})
+	locType  = reflect.TypeOf(time.Location{})
 )
 
 func Unmarshal(data [][]string, v any) error {
@@ -75,6 +81,17 @@ func Unmarshal(data [][]string, v any) error {
 					fmt.Printf("error parsing float64: %v\n", err)
 				}
 				f.SetFloat(f64)
+			case reflect.Struct:
+				typ := f.Type()
+				switch typ {
+				case timeType:
+					t, err := time.Parse(j.timeLayout, record[i])
+					if err != nil {
+						fmt.Printf("error parsing time: %v\n", err)
+					}
+					f.Set(reflect.ValueOf(t))
+				default:
+				}
 			}
 		}
 		pe.Set(reflect.Append(pe, n))

--- a/pkg/csvmum/unmarshal_test.go
+++ b/pkg/csvmum/unmarshal_test.go
@@ -3,6 +3,7 @@ package csvmum
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -143,6 +144,12 @@ func TestUnmarshal(t *testing.T) {
 		data: [][]string{{"A"}, {"three point one four"}},
 		v:    &[]struct{ A float64 }{},
 		res:  &[]struct{ A float64 }{{A: 0}},
+		err:  nil,
+	}, {
+		name: "invalid time",
+		data: [][]string{{"A"}, {"2024-14-35"}},
+		v:    &[]struct{ A time.Time }{},
+		res:  &[]struct{ A time.Time }{{A: time.Time{}}},
 		err:  nil,
 	}}
 


### PR DESCRIPTION
Changelog:
- Add new type `fieldData`
- Rename `getHeaderNamesToIndices` -> `getHeaderData`, now returns `map[string]fieldData`
- Rename `getExportedName` -> `getFieldData`, now returns `fieldData`
- Create predefined tag `timeLayout = "tl"`, `fieldData.timeLayout` defaults to `time.RFC3339`
- `Marshal` now uses `fieldData`, can marshal `time.Time` fields using `fieldData.timeLayout`
- `Unmarshal` now uses `fieldData`, can unmarshal `time.Time` fields using `fieldData.timeLayout`

Updated/changed unit tests:
- `common_test`
- `marshal_test`
- `unmarshal_test`