### PR TITLE
[gtfs] custom MarshalText and UnmarshalText for new Time and Date types

### DIFF
--- a/pkg/gtfs/calendar.go
+++ b/pkg/gtfs/calendar.go
@@ -4,22 +4,21 @@ import (
 	"archive/zip"
 	"encoding/csv"
 	"fmt"
-	"time"
 
 	"github.com/bridgelightcloud/bogie/pkg/csvmum"
 )
 
 type Calendar struct {
-	ServiceID string    `json:"serviceId" csv:"service_id"`
-	Monday    int       `json:"monday" csv:"monday"`
-	Tuesday   int       `json:"tuesday" csv:"tuesday"`
-	Wednesday int       `json:"wednesday" csv:"wednesday"`
-	Thursday  int       `json:"thursday" csv:"thursday"`
-	Friday    int       `json:"friday" csv:"friday"`
-	Saturday  int       `json:"saturday" csv:"saturday"`
-	Sunday    int       `json:"sunday" csv:"sunday"`
-	StartDate time.Time `json:"startDate" csv:"start_date"`
-	EndDate   time.Time `json:"endDate" csv:"end_date"`
+	ServiceID string `json:"serviceId" csv:"service_id"`
+	Monday    int    `json:"monday" csv:"monday"`
+	Tuesday   int    `json:"tuesday" csv:"tuesday"`
+	Wednesday int    `json:"wednesday" csv:"wednesday"`
+	Thursday  int    `json:"thursday" csv:"thursday"`
+	Friday    int    `json:"friday" csv:"friday"`
+	Saturday  int    `json:"saturday" csv:"saturday"`
+	Sunday    int    `json:"sunday" csv:"sunday"`
+	StartDate Date   `json:"startDate" csv:"start_date"`
+	EndDate   Date   `json:"endDate" csv:"end_date"`
 
 	unused []string
 

--- a/pkg/gtfs/calendardates.go
+++ b/pkg/gtfs/calendardates.go
@@ -27,7 +27,7 @@ func (s *GTFSSchedule) parseCalendarDates(file *zip.File) error {
 
 	rc, err := file.Open()
 	if err != nil {
-		s.errors.add( err)
+		s.errors.add(err)
 		return err
 	}
 	defer rc.Close()
@@ -40,7 +40,7 @@ func (s *GTFSSchedule) parseCalendarDates(file *zip.File) error {
 		return ErrEmptyCalendarDatesFile
 	}
 	if err != nil {
-		s.errors.add( err)
+		s.errors.add(err)
 		return err
 	}
 
@@ -61,9 +61,11 @@ func (s *GTFSSchedule) parseCalendarDates(file *zip.File) error {
 			case "service_id":
 				ParseString(v, &cd.ServiceID)
 			case "date":
-				if err := ParseDate(v, &cd.Date); err != nil {
-					s.errors.add( fmt.Errorf("invalid date at line %d: %w", i, err))
+				t, err := time.Parse(dateFormat, v)
+				if err != nil {
+					s.errors.add(fmt.Errorf("invalid date at line %d: %w", i, err))
 				}
+				cd.Date = t
 			case "exception_type":
 				if err := ParseEnum(v, ExceptionType, &cd.ExceptionType); err != nil {
 					s.errors.add(fmt.Errorf("invalid exception_type at line %d: %w", i, err))

--- a/pkg/gtfs/stoptimes.go
+++ b/pkg/gtfs/stoptimes.go
@@ -74,13 +74,17 @@ func (s *GTFSSchedule) parseStopTimes(file *zip.File) error {
 			case "trip_id":
 				ParseString(v, &st.TripID)
 			case "arrival_time":
-				if err := ParseTime(v, &st.ArrivalTime); err != nil {
+				t, err := time.Parse(timeFormat, v)
+				if err != nil {
 					s.errors.add(fmt.Errorf("invalid arrival time at line %d: %w", i, err))
 				}
+				st.ArrivalTime = t
 			case "departure_time":
-				if err := ParseTime(v, &st.DepartureTime); err != nil {
+				t, err := time.Parse(timeFormat, v)
+				if err != nil {
 					s.errors.add(fmt.Errorf("invalid departure time at line %d: %w", i, err))
 				}
+				st.DepartureTime = t
 			case "stop_id":
 				ParseString(v, &st.StopID)
 			case "location_group_id":
@@ -94,13 +98,17 @@ func (s *GTFSSchedule) parseStopTimes(file *zip.File) error {
 			case "stop_headsign":
 				ParseString(v, &st.StopHeadsign)
 			case "start_pickup_drop_off_window":
-				if err := ParseTime(v, &st.StartPickupDropOffWindow); err != nil {
+				t, err := time.Parse(timeFormat, v)
+				if err != nil {
 					s.errors.add(fmt.Errorf("invalid start pickup drop off window at line %d: %w", i, err))
 				}
+				st.StartPickupDropOffWindow = t
 			case "end_pickup_drop_off_window":
-				if err := ParseTime(v, &st.EndPickupDropOffWindow); err != nil {
+				t, err := time.Parse(timeFormat, v)
+				if err != nil {
 					s.errors.add(fmt.Errorf("invalid end pickup drop off window at line %d: %w", i, err))
 				}
+				st.EndPickupDropOffWindow = t
 			case "pickup_type":
 				if err := ParseEnum(v, PickupType, &st.PickupType); err != nil {
 					s.errors.add(fmt.Errorf("invalid pickup type at line %d: %w", i, err))

--- a/pkg/gtfs/trips.go
+++ b/pkg/gtfs/trips.go
@@ -45,7 +45,7 @@ func (s *GTFSSchedule) parseTrips(file *zip.File) error {
 	}
 
 	if err != nil {
-		s.errors.add( err)
+		s.errors.add(err)
 		return err
 	}
 

--- a/pkg/gtfs/types.go
+++ b/pkg/gtfs/types.go
@@ -199,7 +199,6 @@ type Date struct {
 	time.Time
 }
 
-var validDate = regexp.MustCompile(`^\d{8}$`)
 var dateFormat = "20060102"
 
 func (d Date) MarshalText() ([]byte, error) {
@@ -228,26 +227,10 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func ParseDate(v string, t *time.Time) error {
-	f := strings.TrimSpace(v)
-	if !validDate.MatchString(f) {
-		return fmt.Errorf("invalid date format: %s", v)
-	}
-
-	p, err := time.Parse(dateFormat, f)
-	if err != nil {
-		return fmt.Errorf("invalid date value: %s", v)
-	}
-
-	*t = p
-	return nil
-}
-
 type Time struct {
 	time.Time
 }
 
-var validTime = regexp.MustCompile(`^(\d{1,2})\:\d{2}\:\d{2}$`)
 var timeFormat = "15:04:05"
 
 func (t Time) MarshalText() ([]byte, error) {
@@ -305,21 +288,6 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("invalid time value: %s", str)
 	}
 
-	return nil
-}
-
-func ParseTime(v string, t *time.Time) error {
-	f := strings.TrimSpace(v)
-	if !validTime.MatchString(f) {
-		return fmt.Errorf("invalid time format: %s", v)
-	}
-
-	p, err := time.Parse(timeFormat, f)
-	if err != nil {
-		return fmt.Errorf("invalid time value: %s, %s", v, err)
-	}
-
-	*t = p
 	return nil
 }
 

--- a/pkg/gtfs/types.go
+++ b/pkg/gtfs/types.go
@@ -215,8 +215,8 @@ func (d *Date) UnmarshalText(text []byte) error {
 	return nil
 }
 
-func (t Date) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%d", t.Unix())), nil
+func (d Date) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%d", d.Unix())), nil
 }
 
 func (d *Date) UnmarshalJSON(data []byte) error {

--- a/pkg/gtfs/types_test.go
+++ b/pkg/gtfs/types_test.go
@@ -148,66 +148,6 @@ func TestParseCurrencyCode(t *testing.T) {
 	}
 }
 
-func TestParseDate(t *testing.T) {
-	t.Parallel()
-
-	ct := time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC)
-	zt := time.Time{}
-	tt := []struct {
-		value   string
-		expErr  error
-		expTime time.Time
-	}{{
-		value:   "20060102",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   "2006-01-02",
-		expErr:  fmt.Errorf("invalid date format: %s", "2006-01-02"),
-		expTime: zt,
-	}, {
-		value:   "2006/01/02",
-		expErr:  fmt.Errorf("invalid date format: %s", "2006/01/02"),
-		expTime: zt,
-	}, {
-		value:   "20060102 ",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   " 20060102",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   "20060002",
-		expErr:  fmt.Errorf("invalid date value: %s", "20060002"),
-		expTime: zt,
-	}, {
-		value:   " ",
-		expErr:  fmt.Errorf("invalid date format: %s", " "),
-		expTime: zt,
-	}, {
-		value:   "",
-		expErr:  fmt.Errorf("invalid date format: %s", ""),
-		expTime: zt,
-	}}
-
-	for _, tc := range tt {
-		tc := tc
-
-		t.Run(t.Name(), func(t *testing.T) {
-			t.Parallel()
-
-			assert := assert.New(t)
-
-			var d time.Time
-			err := ParseDate(tc.value, &d)
-
-			assert.Equal(tc.expErr, err)
-			assert.Equal(tc.expTime, d)
-		})
-	}
-}
-
 func TestDateMarshalText(t *testing.T) {
 	t.Parallel()
 
@@ -361,70 +301,6 @@ func TestDateUnmarshalJSON(t *testing.T) {
 
 			assert.Equal(tc.date, d)
 			assert.Equal(tc.err, err)
-		})
-	}
-}
-
-func TestParseTime(t *testing.T) {
-	t.Parallel()
-
-	ct := time.Date(0, time.January, 1, 15, 4, 5, 0, time.UTC)
-	zt := time.Time{}
-	tt := []struct {
-		value   string
-		expErr  error
-		expTime time.Time
-	}{{
-		value:   "15:04:05",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   "15:04:05 ",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   " 15:04:05",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   "15:04:05 ",
-		expErr:  nil,
-		expTime: ct,
-	}, {
-		value:   "15:04:05.000",
-		expErr:  fmt.Errorf("invalid time format: %s", "15:04:05.000"),
-		expTime: zt,
-	}, {
-		value:   "3:04:05",
-		expErr:  nil,
-		expTime: time.Date(0, time.January, 1, 3, 4, 5, 0, time.UTC),
-	}, {
-		value:   "03:4:05",
-		expErr:  fmt.Errorf("invalid time format: %s", "03:4:05"),
-		expTime: zt,
-	}, {
-		value:   "30:04:05",
-		expErr:  fmt.Errorf("invalid time value: %s, parsing time \"%s\": hour out of range", "30:04:05", "30:04:05"),
-		expTime: zt,
-	}, {
-		value:   "15:60:05",
-		expErr:  fmt.Errorf("invalid time value: %s, parsing time \"%s\": minute out of range", "15:60:05", "15:60:05"),
-		expTime: zt,
-	}}
-
-	for _, tc := range tt {
-		tc := tc
-
-		t.Run(t.Name(), func(t *testing.T) {
-			t.Parallel()
-
-			assert := assert.New(t)
-
-			var d time.Time
-			err := ParseTime(tc.value, &d)
-
-			assert.Equal(tc.expErr, err)
-			assert.Equal(tc.expTime, d)
 		})
 	}
 }

--- a/pkg/gtfs/types_test.go
+++ b/pkg/gtfs/types_test.go
@@ -438,12 +438,17 @@ func TestTimeMarshalText(t *testing.T) {
 		out  []byte
 		err  error
 	}{{
-		name: "valid date",
+		name: "time under 24 hrs",
 		time: Time{Time: time.Date(1, 1, 1, 12, 55, 30, 0, time.UTC)},
 		out:  []byte("12:55:30"),
 		err:  nil,
 	}, {
-		name: "zero date",
+		name: "time over 24 hrs",
+		time: Time{Time: time.Date(1, 1, 2, 1, 34, 22, 0, time.UTC)},
+		out:  []byte("25:34:22"),
+		err:  nil,
+	}, {
+		name: "zero time",
 		time: Time{Time: time.Time{}},
 		out:  []byte("00:00:00"),
 		err:  nil,
@@ -474,10 +479,14 @@ func TestTimeUnmarshalText(t *testing.T) {
 		time Time
 		err  error
 	}{{
-		name: "valid time",
+		name: "time under 24 hrs",
 		in:   []byte("17:23:22"),
 		time: Time{Time: time.Date(0, 1, 1, 17, 23, 22, 0, time.UTC)},
 		err:  nil,
+	}, {
+		name: "time over 24 hrs",
+		in:   []byte("25:34:22"),
+		time: Time{Time: time.Date(0, 1, 2, 1, 34, 22, 0, time.UTC)},
 	}, {
 		name: "zero time",
 		in:   []byte("00:00:00"),
@@ -489,6 +498,16 @@ func TestTimeUnmarshalText(t *testing.T) {
 		in:   []byte("09:34 AM"),
 		time: Time{Time: time.Time{}},
 		err:  fmt.Errorf("invalid time value: 09:34 AM"),
+	}, {
+		name: "invalid time over 24 hrs",
+		in:   []byte("24:77:22"),
+		time: Time{Time: time.Time{}},
+		err:  fmt.Errorf("invalid time value: 24:77:22"),
+	}, {
+		name: "invalid time under 48 hrs",
+		in:   []byte("48:34:22"),
+		time: Time{Time: time.Time{}},
+		err:  fmt.Errorf("invalid time value: 48:34:22"),
 	}}
 
 	for _, tc := range tt {

--- a/pkg/gtfs/types_test.go
+++ b/pkg/gtfs/types_test.go
@@ -208,6 +208,163 @@ func TestParseDate(t *testing.T) {
 	}
 }
 
+func TestDateMarshalText(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		date Date
+		out  []byte
+		err  error
+	}{{
+		name: "valid date",
+		date: Date{Time: time.Date(2004, 11, 27, 0, 0, 0, 0, time.UTC)},
+		out:  []byte("20041127"),
+		err:  nil,
+	}, {
+		name: "zero date",
+		date: Date{Time: time.Time{}},
+		out:  []byte("00010101"),
+		err:  nil,
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			mt, err := tc.date.MarshalText()
+			assert.Equal(tc.out, mt)
+			assert.Equal(tc.err, err)
+
+		})
+	}
+}
+
+func TestDateUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		in   []byte
+		date Date
+		err  error
+	}{{
+		name: "valid date",
+		in:   []byte("20241127"),
+		date: Date{Time: time.Date(2024, 11, 27, 0, 0, 0, 0, time.UTC)},
+		err:  nil,
+	}, {
+		name: "zero date?",
+		in:   []byte("00010101"),
+		date: Date{Time: time.Time{}},
+		err:  nil,
+	}, {
+		name: "invalid date",
+		in:   []byte("Nov 27, 2024"),
+		date: Date{Time: time.Time{}},
+		err:  fmt.Errorf("invalid date value: Nov 27, 2024"),
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			var d Date
+			err := d.UnmarshalText(tc.in)
+
+			assert.Equal(tc.date, d)
+			assert.Equal(tc.err, err)
+		})
+	}
+}
+
+func TestDateMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		date Date
+		out  []byte
+		err  error
+	}{{
+		name: "valid date",
+		date: Date{Time: time.Date(2024, 11, 27, 0, 0, 0, 0, time.UTC)},
+		out:  []byte("1732665600"),
+		err:  nil,
+	}, {
+		name: "zero date",
+		date: Date{Time: time.Time{}},
+		out:  []byte("-62135596800"),
+		err:  nil,
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			dm, err := tc.date.MarshalJSON()
+
+			assert.Equal(tc.out, dm)
+			assert.Equal(tc.err, err)
+		})
+	}
+}
+
+func TestDateUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		in   []byte
+		date Date
+		err  error
+	}{{
+		name: "valid date",
+		in:   []byte("1732665600"),
+		date: Date{Time: time.Date(2024, 11, 27, 0, 0, 0, 0, time.Local)},
+		err:  nil,
+	}, {
+		name: "zero date",
+		in:   []byte("-62135596800"),
+		date: Date{Time: time.Date(1, 1, 1, 0, 0, 0, 0, time.Local)},
+		err:  nil,
+	}, {
+		name: "invalid date",
+		in:   []byte("x"),
+		// date: Date{Time: time.Date(1, 1, 1, 0, 0, 0, 0, time.Local)},
+		date: Date{Time: time.Time{}},
+		err:  fmt.Errorf("invalid date value: x"),
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			var d Date
+			err := d.UnmarshalJSON(tc.in)
+
+			assert.Equal(tc.date, d)
+			assert.Equal(tc.err, err)
+		})
+	}
+}
+
 func TestParseTime(t *testing.T) {
 	t.Parallel()
 
@@ -268,6 +425,162 @@ func TestParseTime(t *testing.T) {
 
 			assert.Equal(tc.expErr, err)
 			assert.Equal(tc.expTime, d)
+		})
+	}
+}
+
+func TestTimeMarshalText(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		time Time
+		out  []byte
+		err  error
+	}{{
+		name: "valid date",
+		time: Time{Time: time.Date(1, 1, 1, 12, 55, 30, 0, time.UTC)},
+		out:  []byte("12:55:30"),
+		err:  nil,
+	}, {
+		name: "zero date",
+		time: Time{Time: time.Time{}},
+		out:  []byte("00:00:00"),
+		err:  nil,
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			mt, err := tc.time.MarshalText()
+			assert.Equal(tc.out, mt)
+			assert.Equal(tc.err, err)
+
+		})
+	}
+}
+
+func TestTimeUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		in   []byte
+		time Time
+		err  error
+	}{{
+		name: "valid time",
+		in:   []byte("17:23:22"),
+		time: Time{Time: time.Date(0, 1, 1, 17, 23, 22, 0, time.UTC)},
+		err:  nil,
+	}, {
+		name: "zero time",
+		in:   []byte("00:00:00"),
+		time: Time{Time: time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC)},
+		// time: Time{Time: time.Time{}},
+		err: nil,
+	}, {
+		name: "invalid time",
+		in:   []byte("09:34 AM"),
+		time: Time{Time: time.Time{}},
+		err:  fmt.Errorf("invalid time value: 09:34 AM"),
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			var time Time
+			err := time.UnmarshalText(tc.in)
+
+			assert.Equal(tc.time, time)
+			assert.Equal(tc.err, err)
+		})
+	}
+}
+
+func TestTimeMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		time Time
+		out  []byte
+		err  error
+	}{{
+		name: "valid time",
+		time: Time{Time: time.Date(1, 1, 1, 12, 57, 44, 0, time.UTC)},
+		out:  []byte("-62135550136"),
+		err:  nil,
+	}, {
+		name: "zero time",
+		time: Time{Time: time.Time{}},
+		out:  []byte("null"),
+		err:  nil,
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			dm, err := tc.time.MarshalJSON()
+
+			assert.Equal(tc.out, dm)
+			assert.Equal(tc.err, err)
+		})
+	}
+}
+
+func TestTimeUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+		in   []byte
+		time Time
+		err  error
+	}{{
+		name: "valid time",
+		in:   []byte("-62135550136"),
+		time: Time{Time: time.Date(1, 1, 1, 12, 57, 44, 0, time.Local)}, err: nil,
+	}, {
+		name: "zero time",
+		in:   []byte("null"),
+		time: Time{Time: time.Time{}},
+		err:  nil,
+	}, {
+		name: "invalid time",
+		in:   []byte("x"),
+		time: Time{Time: time.Time{}},
+		err:  fmt.Errorf("invalid time value: x"),
+	}}
+
+	for _, tc := range tt {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert := assert.New(t)
+
+			var d Time
+			err := d.UnmarshalJSON(tc.in)
+
+			assert.Equal(tc.time, d)
+			assert.Equal(tc.err, err)
 		})
 	}
 }


### PR DESCRIPTION
Change log:
- New type `Date`
  - `(d Date) MarshalText() ([]byte, error)`
  - `(d *Date) UnmarshalText(text []byte) error`
  - `(d Date) MarshalJSON() ([]byte, error)`
  - `(d *Date) UnmarshalJSON(data []byte) error`
- Remove `ParseDate`
- New type `Time`
  - `(t Time) MarshalText() ([]byte, error)`
  - `(t *Time) UnmarshalText(text []byte) error`
  - `(t Time) MarshalJSON() ([]byte, error)`
  - `(t *Time) UnmarshalJSON(data []byte) error`
- Remove `ParseTime`

Unit tests created or updated:
- `pkg/gtfs/type_test.go`
  - `TestDateMarshalText`
  - `TestDateUnmarshalText`
  - `TestDateMarshalJSON`
  - `TestDateUnmarshalJSON`
  - `TestTimeMarshalText`
  - `TestTimeUnmarshalText`
  - `TestTimeMarshalJSON`
  - `TestTimeUnmarshalJSON`
- Remove `TestParseDate`
- Remove `TestParseTime`