### PR TITLE
[csvmum] handle custom text marshal and ummarshal

### DIFF
--- a/pkg/csvmum/README.md
+++ b/pkg/csvmum/README.md
@@ -35,7 +35,7 @@ func main() {
 
 	out, err := csvmum.Marshal(tt)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("Error: %w\n", err)
 	}
 	fmt.Printf("%d headers\n", len(out[0]))
 

--- a/pkg/csvmum/marshal.go
+++ b/pkg/csvmum/marshal.go
@@ -22,7 +22,7 @@ func Marshal(v any) ([][]string, error) {
 	typ := reflect.ValueOf(s.Index(0).Interface()).Type()
 	hm, err := getHeaderNamesToIndices(typ)
 	if err != nil {
-		return out, fmt.Errorf("cannot marshal: %s", err)
+		return out, fmt.Errorf("cannot marshal: %w", err)
 	}
 
 	hs := getOrderedHeaders(hm)
@@ -38,7 +38,7 @@ func Marshal(v any) ([][]string, error) {
 			if m, ok := field.Interface().(encoding.TextMarshaler); ok {
 				b, err := m.MarshalText()
 				if err != nil {
-					return out, fmt.Errorf("cannot marshal: %s", err)
+					return out, fmt.Errorf("cannot marshal: %w", err)
 				}
 				record = append(record, string(b))
 				continue

--- a/pkg/csvmum/marshal.go
+++ b/pkg/csvmum/marshal.go
@@ -1,6 +1,7 @@
 package csvmum
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -33,6 +34,16 @@ func Marshal(v any) ([][]string, error) {
 		record := []string{}
 		for _, n := range hs {
 			field := item.Field(hm[n])
+
+			if m, ok := field.Interface().(encoding.TextMarshaler); ok {
+				b, err := m.MarshalText()
+				if err != nil {
+					return out, err
+				}
+				record = append(record, string(b))
+				continue
+			}
+
 			switch field.Kind() {
 			case reflect.String:
 				record = append(record, fmt.Sprintf("%s", field.String()))

--- a/pkg/csvmum/marshal.go
+++ b/pkg/csvmum/marshal.go
@@ -22,7 +22,7 @@ func Marshal(v any) ([][]string, error) {
 	typ := reflect.ValueOf(s.Index(0).Interface()).Type()
 	hm, err := getHeaderNamesToIndices(typ)
 	if err != nil {
-		return out, err
+		return out, fmt.Errorf("cannot marshal: %s", err)
 	}
 
 	hs := getOrderedHeaders(hm)
@@ -38,7 +38,7 @@ func Marshal(v any) ([][]string, error) {
 			if m, ok := field.Interface().(encoding.TextMarshaler); ok {
 				b, err := m.MarshalText()
 				if err != nil {
-					return out, err
+					return out, fmt.Errorf("cannot marshal: %s", err)
 				}
 				record = append(record, string(b))
 				continue

--- a/pkg/csvmum/marshal_test.go
+++ b/pkg/csvmum/marshal_test.go
@@ -75,7 +75,7 @@ type customMarshal struct {
 
 func (c customMarshal) MarshalText() ([]byte, error) {
 	if len(c.One) == 0 {
-		return []byte{}, fmt.Errorf("invalid text: %s", c.One)
+		return nil, fmt.Errorf("invalid text: %s", c.One)
 	}
 
 	return []byte(fmt.Sprintf("~%s~", c.One)), nil

--- a/pkg/csvmum/unmarshal.go
+++ b/pkg/csvmum/unmarshal.go
@@ -48,7 +48,6 @@ func Unmarshal(data [][]string, v any) error {
 			continue
 		}
 		if len(record) != len(headers) {
-			fmt.Printf("record has %d fields, headers has %d\n", len(record), len(headers))
 			continue
 		}
 

--- a/pkg/csvmum/unmarshal.go
+++ b/pkg/csvmum/unmarshal.go
@@ -1,6 +1,7 @@
 package csvmum
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -54,6 +55,15 @@ func Unmarshal(data [][]string, v any) error {
 		n := reflect.New(typ).Elem()
 		for i, j := range hm {
 			f := n.Field(j)
+
+			if m, ok := f.Addr().Interface().(encoding.TextUnmarshaler); ok {
+				err := m.UnmarshalText([]byte(record[i]))
+				if err != nil {
+					return fmt.Errorf("cannot unmarshal: %v", err)
+				}
+				continue
+			}
+
 			switch f.Kind() {
 			case reflect.String:
 				f.SetString(record[i])

--- a/pkg/csvmum/unmarshal.go
+++ b/pkg/csvmum/unmarshal.go
@@ -58,7 +58,7 @@ func Unmarshal(data [][]string, v any) error {
 			if m, ok := f.Addr().Interface().(encoding.TextUnmarshaler); ok {
 				err := m.UnmarshalText([]byte(record[i]))
 				if err != nil {
-					return fmt.Errorf("cannot unmarshal: %v", err)
+					return fmt.Errorf("cannot unmarshal: %w", err)
 				}
 				continue
 			}

--- a/tools/csvmum/main.go
+++ b/tools/csvmum/main.go
@@ -3,12 +3,53 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/bridgelightcloud/bogie/pkg/csvmum"
+	"github.com/bridgelightcloud/bogie/pkg/gtfs"
 )
 
 func main() {
-	b()
+	c()
+}
+
+type thing struct {
+	Date gtfs.Date `csv:"date"`
+	Time gtfs.Time `csv:"time"`
+
+	Heh string
+}
+
+func c() {
+	t := []thing{
+		{
+			Date: gtfs.Date{Time: time.Time{}},
+			Time: gtfs.Time{Time: time.Time{}},
+			Heh:  "heh",
+		},
+		{Date: gtfs.Date{Time: time.Date(2024, 11, 26, 14, 14, 0, 0, time.UTC)}, Heh: "heh"},
+		{Time: gtfs.Time{Time: time.Date(0, 0, 0, 14, 15, 23, 0, time.UTC)}},
+	}
+
+	out, err := csvmum.Marshal(t)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("out: %v\n", out)
+
+	td := [][]string{
+		{"date", "time", "Heh"},
+		{"20241126", "14:14:00", "heh"},
+		{"19860922", "14:15:23", ""},
+	}
+
+	var t2 []thing
+	err = csvmum.Unmarshal(td, &t2)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("t2: %v\n", t2)
+
 }
 
 func b() {


### PR DESCRIPTION
Change log:
- Add support for values that satisfy `encoding.TextMarshaler`
- Add support for values that satisfy `encoding.TextUnmarshaler`

Unit tests:
- `TestMarshalTextMarshaler`
- `TestUnmarshalTextMarshaler`